### PR TITLE
Wrap dd_CopyInputIncidence

### DIFF
--- a/test/incidence.jl
+++ b/test/incidence.jl
@@ -15,4 +15,17 @@ using CDDLib
         vrep(p)
         @test Set(copyincidence(p.poly)) == incidence_extected
     end
+
+    @testset "Input incidence $precision" for precision in [:float, :exact]
+        V = [[1//2, 1//2], [0, 1], [0, 0]]
+        incidence_extected = Set([
+            BitSet([1, 2]),
+            BitSet([1, 3]),
+            BitSet([2, 3])
+        ])
+        p = polyhedron(vrep(V), CDDLib.Library(precision))
+        @test p isa CDDLib.Polyhedron{precision == :float ? Float64 : Rational{BigInt}}
+        hrep(p)
+        @test Set(copyinputincidence(p.poly)) == incidence_extected
+    end
 end

--- a/test/incidence.jl
+++ b/test/incidence.jl
@@ -18,14 +18,15 @@ using CDDLib
 
     @testset "Input incidence $precision" for precision in [:float, :exact]
         V = [[1//2, 1//2], [0, 1], [0, 0]]
-        incidence_extected = Set([
-            BitSet([1, 2]),
-            BitSet([1, 3]),
-            BitSet([2, 3])
-        ])
         p = polyhedron(vrep(V), CDDLib.Library(precision))
-        @test p isa CDDLib.Polyhedron{precision == :float ? Float64 : Rational{BigInt}}
+        T = Polyhedra.coefficient_type(p)
         hrep(p)
-        @test Set(copyinputincidence(p.poly)) == incidence_extected
+        incidence_computed = copyinputincidence(p.poly)
+        for v in eachindex(points(p))
+            for i in incidence_computed[v.value]
+                h = Polyhedra.Index{T, HalfSpace{T, Vector{T}}}(i)
+                @test Polyhedra.isincident(p, v, h; tol=0)
+            end
+        end
     end
 end


### PR DESCRIPTION
Addition to #95

```julia
julia> using CDDLib, Polyhedra

julia> V = [[1//2, 1//2], [0, 1], [0, 0]];

julia> p = polyhedron(vrep(V), CDDLib.Library(:exact))
Polyhedron CDDLib.Polyhedron{Rational{BigInt}}:
3-element iterator of Vector{Rational{BigInt}}:
 Rational{BigInt}[1//2, 1//2]
 Rational{BigInt}[0, 1]
 Rational{BigInt}[0, 0]

julia> hrep(p)
H-representation CDDInequalityMatrix{Rational{BigInt}, GMPRational}:
3-element iterator of HalfSpace{Rational{BigInt}, Vector{Rational{BigInt}}}:
 HalfSpace(Rational{BigInt}[1, 1], 1//1)
 HalfSpace(Rational{BigInt}[-1, 0], 0//1)
 HalfSpace(Rational{BigInt}[1, -1], 0//1)

julia> copyinputincidence(p.poly)
3-element Vector{BitSet}:
 BitSet([1, 3])
 BitSet([1, 2])
 BitSet([2, 3])
```