### PR TITLE
Add `Base.get(p, inc)` and `incident*` functions without `tol`

### DIFF
--- a/src/CDDLib.jl
+++ b/src/CDDLib.jl
@@ -25,5 +25,6 @@ include("lp.jl")
 
 include("MOI_wrapper.jl")
 include("polyhedron.jl")
+include("incidence.jl")
 
 end # module

--- a/src/incidence.jl
+++ b/src/incidence.jl
@@ -1,0 +1,39 @@
+_getrepfor(p::Polyhedron{T}, ::Polyhedra.Incident{T, <:HRepElement{T}}) where {T} = getine(p)
+_getrepfor(p::Polyhedron{T}, ::Polyhedra.Incident{T, <:VRepElement{T}}) where {T} = getext(p)
+_getincidence(p::Polyhedron{T}, ::Polyhedra.Incident{T, <:HRepElement{T}}) where {T} = gethincidence(p)
+_getincidence(p::Polyhedron{T}, ::Polyhedra.Incident{T, <:VRepElement{T}}) where {T} = getvincidence(p)
+_incel(p::Polyhedron{T}, inc::Polyhedra.IncidentElements{T}, idx) where {T} = get(p, idx)
+_incel(p::Polyhedron{T}, inc::Polyhedra.IncidentIndices{T}, idx) where {T} = idx
+
+function Base.get(p::Polyhedron{T}, inc::Polyhedra.Incident{T, ElemT}) where {T, ElemT}
+    rep = _getrepfor(p, inc)
+    incidence = _getincidence(p, inc)
+    incT = Polyhedra._inctype(inc)
+    incs = incT[]
+    for i in incidence[inc.idx.value]
+        idx = Polyhedra.Index{T, ElemT}(i)
+        isvalid(rep, idx) && push!(incs, _incel(p, inc, idx))
+    end
+    return incs
+end
+
+
+for loop_singular in (:point, :line, :ray, :hyperplane, :halfspace)
+    singularstr = string(loop_singular)
+    elemtype = Symbol(singularstr * "type")
+    pluralstr = singularstr * "s"
+    inc = Symbol("incident" * pluralstr)
+    incidx = Symbol("incident" * singularstr * "indices")
+
+    @eval begin
+        # incidentpoints, incidentlines, incidentrays,
+        # incidenthyperplanes, incidenthalfspaces
+        Polyhedra.$inc(p::Polyhedron{T}, idx) where {T} =
+            get(p, Polyhedra.IncidentElements{T, $elemtype(p)}(p, idx))
+
+        # incidentpointindices, incidentlineindices, incidentrayindices,
+        # incidenthyperplaneindices, incidenthalfspaceindices
+        Polyhedra.$incidx(p::Polyhedron{T}, idx) where {T} =
+            get(p, Polyhedra.IncidentIndices{T, $elemtype(p)}(p, idx))
+    end
+end

--- a/src/incidence.jl
+++ b/src/incidence.jl
@@ -8,8 +8,12 @@ _incel(p::Polyhedron{T}, inc::Polyhedra.IncidentIndices{T}, idx) where {T} = idx
 function Base.get(p::Polyhedron{T}, inc::Polyhedra.Incident{T, ElemT}) where {T, ElemT}
     rep = _getrepfor(p, inc)
     incidence = _getincidence(p, inc)
+    row = incidence[inc.idx.value]
+
     incT = Polyhedra._inctype(inc)
     incs = incT[]
+    sizehint!(incs, length(row))
+
     for i in incidence[inc.idx.value]
         idx = Polyhedra.Index{T, ElemT}(i)
         isvalid(rep, idx) && push!(incs, _incel(p, inc, idx))

--- a/test/incidence.jl
+++ b/test/incidence.jl
@@ -2,6 +2,60 @@ using Test
 using Polyhedra
 using CDDLib
 
+# Generate test functions that test incident* functions
+plural(x) = Symbol(x, "s")
+idx(x) = Symbol(x, "idx")
+inc(x) = Symbol("incident", plural(x))
+incidx(x) = Symbol("incident", x, "indices")
+
+v_kinds = (:point, :line, :ray)
+h_kinds = (:hyperplane, :halfspace)
+
+vars = Dict(
+    :hyperplane => :hp,
+    :halfspace  => :hs,
+    :point      => :pt,
+    :line       => :ln,
+    :ray        => :ry,
+)
+
+patterns = [
+    # {hyperplane, halfspace} -> {point, line, ray}
+    [(plural(s), idx(vars[s]), vars[s], plural(t), inc(t), incidx(t))
+     for s in h_kinds for t in v_kinds]...,
+    # {point, line, ray} -> {hyperplane, halfspace}
+    [(plural(s), idx(vars[s]), vars[s], plural(t), inc(t), incidx(t))
+     for s in v_kinds for t in h_kinds]...
+]  # 12 patterns
+
+# Code generation
+for (src_plural, src_idx, src_var, tgt_plural, inc_fun, incidx_fun) in patterns
+    fname = Symbol("test_", src_plural, "_", inc_fun)
+
+    @eval function $(fname)(p::CDDLib.Polyhedron)
+        T = Polyhedra.coefficient_type(p)
+        tol = Polyhedra._default_tol(T)
+
+        srcs = $(src_plural)(p)
+        for ($(src_idx), $(src_var)) in zip(eachindex(srcs), srcs)
+            inc_elems = @inferred $(inc_fun)(p, $(src_idx))
+            inc_inds  = @inferred $(incidx_fun)(p, $(src_idx))
+
+            for elems in (inc_elems, get.(p, inc_inds))
+                for el in elems
+                    @test Polyhedra.isincident(el, $(src_var), tol=tol)
+                end
+            end
+
+            # Test against the generic versions in Polyhedra.jl
+            @test inc_elems == $(inc_fun)(p, $(src_idx), tol=tol)
+            @test inc_inds  == $(incidx_fun)(p, $(src_idx), tol=tol)
+        end
+        return nothing
+    end
+end
+
+
 @testset "Incidence tests" begin
     @testset "Incidence $precision" for precision in [:float, :exact]
         A = [1 1; 1 -1; -1 0]; b = [1, 0, 0]
@@ -66,6 +120,62 @@ using CDDLib
             for (hidx, h) in enumerate(hs)
                 for i in p.vincidence[hidx]
                     @test Polyhedra.isincident(vs[i], h, tol=tol)
+                end
+            end
+        end
+    end
+
+    @testset "incident* functions $precision" for precision in [:float, :exact]
+        lib = CDDLib.Library(precision)
+
+        # Case 1: points + lines
+        A1 = [-1 0; 1 0]
+        b1 = [0, 1]
+        p1 = polyhedron(hrep(A1, b1), lib)
+        vrep(p1)
+
+        # Case 2: points + rays + lines + halfspaces + hyperplanes
+        # P = { (x,y,z,w) | -1 <= x <= 1, y >= 0, z == 0, w free }.
+        A2 = [
+             1  0  0  0;   # x <= 1
+            -1  0  0  0;   # -x <= 1  (x >= -1)
+             0 -1  0  0;   # -y <= 0  (y >= 0)
+             0  0  1  0;   # z <= 0, marked as equality -> z == 0
+        ]
+        b2 = [1, 1, 0, 0]
+        linset2 = BitSet([4])
+        p2 = polyhedron(hrep(A2, b2, linset2), lib)
+        vrep(p2)
+
+        # Case 3: bounded triangle (points + halfspaces)
+        p3 = polyhedron(hrep([1 1; 1 -1; -1 0], [1, 0, 0]), lib)
+        vrep(p3)
+
+        # Case 4: homogeneous cone from rays (V-input; exercises the cone branch)
+        p4 = polyhedron(conichull([1, 0], [0, 1]), lib)
+        hrep(p4)
+
+        # Case 5: non-homogeneous cone / translated orthant (point + rays)
+        # P = { (x, y) | x >= 1, y >= 1 }.
+        p5 = polyhedron(hrep([-1 0; 0 -1], [-1, -1]), lib)
+        vrep(p5)
+
+        # Case 6: empty / infeasible (H-side elements only)
+        # x == 0, x == 1, y >= 0.
+        p_empty = polyhedron(hrep([1 0; 1 0; 0 -1], [0, 1, 0], BitSet([1, 2])), lib)
+        vrep(p_empty)
+
+        # Case 7: whole space, represented by line directions (no constraints)
+        p_full = polyhedron(vrep([Line([1, 0]), Line([0, 1])]), lib)
+        hrep(p_full)
+
+        ps = (p1, p2, p3, p4, p5, p_empty, p_full)
+
+        for (src_plural, src_idx, src_var, tgt_plural, inc_fun, incidx_fun) in patterns
+            fname = Symbol("test_", src_plural, "_", inc_fun)
+            @testset "$(src_plural) -> $(tgt_plural)" begin
+                for p in ps
+                    getfield(@__MODULE__, fname)(p)
                 end
             end
         end


### PR DESCRIPTION
Address #21
(Yet to add tests)

* [x] Add tests.

@blegat I propose to implement `Base.get(p, inc)` (and `incident*` functions) without `tol`, rather than overwriting [`Base.get(p, inc; tol)`](https://github.com/JuliaPolyhedra/Polyhedra.jl/blob/42ae3253abde94424d10dde44a20a11c3e869d45/src/incidence.jl#L7-L17) (the implementation here does not use `tol`).

```julia
using Polyhedra, CDDLib, LinearAlgebra
n = 3
pts = vcat(zeros(1, n), Matrix(I, n, n))
p = polyhedron(vrep(pts), CDDLib.Library())
hrep(p)
p
```
```
Polyhedron CDDLib.Polyhedron{Float64}:
4-element iterator of HalfSpace{Float64, Vector{Float64}}:
 HalfSpace([1.0, 1.0, 1.0], 1.0)
 HalfSpace([-1.0, -0.0, -0.0], 0.0)
 HalfSpace([-0.0, -1.0, -0.0], 0.0)
 HalfSpace([-0.0, -0.0, -1.0], 0.0):
4-element iterator of Vector{Float64}:
 [0.0, 0.0, 0.0]
 [1.0, 0.0, 0.0]
 [0.0, 1.0, 0.0]
 [0.0, 0.0, 1.0]
```
```julia
T = Polyhedra.coefficient_type(p)
i = 1
idx = Polyhedra.Index{T,Vector{T}}(i)
display(incidenthalfspaces(p, idx))  # Version implemented in this PR
display(incidenthalfspaces(p, idx, tol=0))  # Version in Polyhedra.jl
```
```
3-element Vector{HalfSpace{Float64, Vector{Float64}}}:
 HalfSpace([-1.0, -0.0, -0.0], 0.0)
 HalfSpace([-0.0, -1.0, -0.0], 0.0)
 HalfSpace([-0.0, -0.0, -1.0], 0.0)
3-element Vector{HalfSpace{Float64, Vector{Float64}}}:
 HalfSpace([-1.0, -0.0, -0.0], 0.0)
 HalfSpace([-0.0, -1.0, -0.0], 0.0)
 HalfSpace([-0.0, -0.0, -1.0], 0.0)
```